### PR TITLE
Fixed incorrect variable name

### DIFF
--- a/EditableAction.php
+++ b/EditableAction.php
@@ -59,7 +59,7 @@ class EditableAction extends Action
     {
         $class = $this->modelClass;
         $pk = Yii::$app->request->post('pk');
-        $pk = unserialize(base64_decode($key));
+        $pk = unserialize(base64_decode($pk));
         $attribute = Yii::$app->request->post('name');
         $value = Yii::$app->request->post('value');
         if ($attribute === null) {


### PR DESCRIPTION
The encoded variable must be $pk and not $key.
