### PR TITLE
Security bug using scenario

### DIFF
--- a/src/EditableAction.php
+++ b/src/EditableAction.php
@@ -84,7 +84,9 @@ class EditableAction extends Action
         if ($this->scenario !== null) {
             $model->setScenario($this->scenario);
         }
-        $model->$attribute = $value;
+        $model->setAttributes([
+            $attribute => $value
+        ]);
 
         if ($model->validate([$attribute])) {
             // no need to specify which attributes as Yii2 handles that via [[BaseActiveRecord::getDirtyAttributes]]


### PR DESCRIPTION
Scenario is not working as it supposed to work. Attribute is still assigned to model, but validation rules are not applied to attribute.

Let's say we have such configuration for our update action:
```
'update' => [
    'class' => EditableAction::class,
    'modelClass' => Customer::class,
    'forceCreate' => false,
    'scenario' => Customer::SCENARIO_CLIENT_FORM,
],
```
And this configuration in our model:
```
public function rules()
{
    return array_merge(parent::rules(), [
        [['email'], 'email'],
    ]);
}
public function scenarios()
{
    return array_merge(parent::scenarios(), [
        static::SCENARIO_CLIENT_FORM => ['name', 'surname'],
    ]);
}
```

User was able to change his e-mail address and even to wrong value, because attribute is not validated.

This is because we have such line in EditableAction:
```
$model->$attribute = $value;
```

Which should be changed to:
```
$model->setAttributes([
    $attribute => $value,
]);
```

Basically user is able to change even his ID number.