### PR TITLE
remove call_user_func() method usage

### DIFF
--- a/src/Editable.php
+++ b/src/Editable.php
@@ -102,8 +102,6 @@ class Editable extends InputWidget
         $value = $this->value;
         if ($this->hasModel() && $value === null) {
             $show = Html::getAttributeValue($this->model, $this->attribute);
-        } elseif (is_callable($value)) {
-            $show = call_user_func($value, $this->model);
         } else {
             $show = $value;
         }


### PR DESCRIPTION
to prevent function injections, because the callable value is provided by user

relates to #40 